### PR TITLE
allow import from derivation

### DIFF
--- a/nixbuild-action.sh
+++ b/nixbuild-action.sh
@@ -154,7 +154,8 @@ egrep -v "substituters =|trusted-public-keys =" "$NIX_CONF_FILE" >"$NIX_CONF_FIL
 cat >>"$NIX_CONF_FILE.tmp" <<EOF
 $substituters
 $public_keys
-max-jobs = 0
+max-jobs = 1
+allow-import-from-derivation = true
 builders = @$NIX_BUILDERS_FILE
 builders-use-substitutes = true
 require-sigs = true


### PR DESCRIPTION
1 job should be allowed

> Depending on how you have configured Nix, you might also need to specify --max-jobs 1 to allow local builds to run during evaluation. - https://docs.nixbuild.net/remote-builds/#ifd-builds-import-from-derivation